### PR TITLE
Add QQuickViews to QtOffscreenViews files.pri

### DIFF
--- a/QJniHelpers/QJniHelpers.pri
+++ b/QJniHelpers/QJniHelpers.pri
@@ -1,17 +1,14 @@
-android-g++ {
+INCLUDEPATH += $$PWD
+QT += androidextras
 
-    INCLUDEPATH += $$PWD
-    QT += androidextras
+HEADERS += \
+    $$PWD/QJniHelpers.h \
+    $$PWD/QJniLangUtils.h \
+    $$PWD/QAndroidQPAPluginGap.h \
+    $$PWD/IJniObjectLinker.h \
+    $$PWD/TJniObjectLinker.h \
 
-    HEADERS += \
-        $$PWD/QJniHelpers.h \
-        $$PWD/QJniLangUtils.h \
-        $$PWD/QAndroidQPAPluginGap.h \
-        $$PWD/IJniObjectLinker.h \
-        $$PWD/TJniObjectLinker.h \
-
-    SOURCES += \
-        $$PWD/QJniHelpers.cpp \
-        $$PWD/QJniLangUtils.cpp \
-        $$PWD/QAndroidQPAPluginGap.cpp \
-}
+SOURCES += \
+    $$PWD/QJniHelpers.cpp \
+    $$PWD/QJniLangUtils.cpp \
+    $$PWD/QAndroidQPAPluginGap.cpp \

--- a/QtAndroidHelpers/QtAndroidHelpers.pri
+++ b/QtAndroidHelpers/QtAndroidHelpers.pri
@@ -1,6 +1,3 @@
-
-android-g++ {
-
 INCLUDEPATH += $$PWD
 
 HEADERS += \
@@ -53,4 +50,3 @@ SOURCES += \
     $$PWD/QAndroidToast.cpp \
     $$PWD/QAndroidDesktopUtils.cpp \
     $$PWD/QAndroidStorages.cpp
-}

--- a/QtAndroidHelpers/ru.dublgis.androidhelpers/KeyboardHeightProvider.java
+++ b/QtAndroidHelpers/ru.dublgis.androidhelpers/KeyboardHeightProvider.java
@@ -106,9 +106,9 @@ public class KeyboardHeightProvider
     }
 
 
-    private int nominalScreenHeight() {
+    private int realScreenHeight() {
         final Point screenSize = new Point();
-        mActivity.getWindowManager().getDefaultDisplay().getSize(screenSize);
+        mActivity.getWindowManager().getDefaultDisplay().getRealSize(screenSize);
         return screenSize.y;
     }
 
@@ -123,7 +123,7 @@ public class KeyboardHeightProvider
     private int getKeyboardSize() {
         int keyboardHeight = 0;
         try {
-            final int screenHeight = nominalScreenHeight();
+            final int screenHeight = realScreenHeight();
             keyboardHeight = screenHeight - visibleDisplayFrameHeight();
             if (keyboardHeight == 0
                 || !SystemNavigationBarInfo.deviceMayHaveFullscreenMode(mActivity) // Fast (cached)
@@ -140,7 +140,7 @@ public class KeyboardHeightProvider
             // in the future. But we really have no choice.
 
             /*
-            Log.d(TAG"getNavigationBarHeightFromConfiguration=" +
+            Log.d(TAG, "getNavigationBarHeightFromConfiguration=" +
                 SystemNavigationBarInfo.getNavigationBarHeightFromConfiguration(
                     Configuration.ORIENTATION_PORTRAIT) +
                 ", screenHeight=" + screenHeight +
@@ -155,19 +155,13 @@ public class KeyboardHeightProvider
 
             final boolean fullscreen = SystemNavigationBarInfo.isInFullscreenMode(mActivity);
             final boolean hasNavBarSpace = SystemNavigationBarInfo.hasVerticalNavBarSpace(mActivity);
-
-            // Correcting for "control is too high above the keyboard" case
-            if (!fullscreen && !hasNavBarSpace) {
-                return keyboardHeight - SystemNavigationBarInfo.getActualNavigationBarControlHeight(mActivity);
-            }
-
-            // Correcting for "control is partially or fully covered by the keyboard" case
-            if (fullscreen &&
-                hasNavBarSpace &&
-                SystemNavigationBarInfo.getActualNavigationBarControlHeight(mActivity) == 0)
-            {
-                return keyboardHeight + SystemNavigationBarInfo.getNavigationBarHeightFromConfiguration(
-                    Configuration.ORIENTATION_PORTRAIT);
+            if (!fullscreen && hasNavBarSpace) {
+                int navBarHeight = SystemNavigationBarInfo.getActualNavigationBarControlHeight(mActivity);
+                if (navBarHeight == 0) {
+                    navBarHeight = SystemNavigationBarInfo.getNavigationBarHeightFromConfiguration(
+                        Configuration.ORIENTATION_PORTRAIT);
+                }
+                return keyboardHeight - navBarHeight;
             }
         } catch (final Throwable e) {
             Log.e(TAG, "getKeyboardSize exception: " + e);

--- a/QtOffscreenViews/files.pri
+++ b/QtOffscreenViews/files.pri
@@ -1,28 +1,34 @@
 HEADERS += \
-    QOpenGLTextureHolder.h \
-    QAndroidOffscreenView.h \
-    QAndroidOffscreenWebView.h \
-    QAndroidOffscreenEditText.h \
-    QAndroidJniImagePair.h \
-    QApplicationActivityObserver.h \
-    QGraphicsWidgets/QAndroidOffscreenViewGraphicsWidget.h \
-    QGraphicsWidgets/QOffscreenEditTextGraphicsWidget.h \
-    QGraphicsWidgets/QOffscreenWebViewGraphicsWidget.h
+    $$PWD/QOpenGLTextureHolder.h \
+    $$PWD/QAndroidOffscreenView.h \
+    $$PWD/QAndroidOffscreenWebView.h \
+    $$PWD/QAndroidOffscreenEditText.h \
+    $$PWD/QAndroidJniImagePair.h \
+    $$PWD/QApplicationActivityObserver.h \
+    $$PWD/QGraphicsWidgets/QAndroidOffscreenViewGraphicsWidget.h \
+    $$PWD/QGraphicsWidgets/QOffscreenEditTextGraphicsWidget.h \
+    $$PWD/QGraphicsWidgets/QOffscreenWebViewGraphicsWidget.h \
+    $$PWD/QQuickViews/QQuickAndroidOffscreenView.h \
+    $$PWD/QQuickViews/QQuickOffscreenEditText.h \
+    $$PWD/QQuickViews/QQuickOffscreenWebView.h
 
 SOURCES += \
-    QOpenGLTextureHolder.cpp \
-    QAndroidOffscreenView.cpp \
-    QAndroidOffscreenWebView.cpp \
-    QAndroidOffscreenEditText.cpp \
-    QAndroidJniImagePair.cpp \
-    QApplicationActivityObserver.cpp \
-    QGraphicsWidgets/QAndroidOffscreenViewGraphicsWidget.cpp \
-    QGraphicsWidgets/QOffscreenEditTextGraphicsWidget.cpp \
-    QGraphicsWidgets/QOffscreenWebViewGraphicsWidget.cpp
+    $$PWD/QOpenGLTextureHolder.cpp \
+    $$PWD/QAndroidOffscreenView.cpp \
+    $$PWD/QAndroidOffscreenWebView.cpp \
+    $$PWD/QAndroidOffscreenEditText.cpp \
+    $$PWD/QAndroidJniImagePair.cpp \
+    $$PWD/QApplicationActivityObserver.cpp \
+    $$PWD/QGraphicsWidgets/QAndroidOffscreenViewGraphicsWidget.cpp \
+    $$PWD/QGraphicsWidgets/QOffscreenEditTextGraphicsWidget.cpp \
+    $$PWD/QGraphicsWidgets/QOffscreenWebViewGraphicsWidget.cpp \
+    $$PWD/QQuickViews/QQuickAndroidOffscreenView.cpp \
+    $$PWD/QQuickViews/QQuickOffscreenEditText.cpp \
+    $$PWD/QQuickViews/QQuickOffscreenWebView.cpp
 
 
 OTHER_FILES += \
-    ru.dublgis.offscreenview/OffscreenViewFactory.java \
-    ru.dublgis.offscreenview/OffscreenView.java \
-    ru.dublgis.offscreenview/OffscreenWebView.java \
-    ru.dublgis.offscreenview/OffscreenEditText.java
+    $$PWD/ru.dublgis.offscreenview/OffscreenViewFactory.java \
+    $$PWD/ru.dublgis.offscreenview/OffscreenView.java \
+    $$PWD/ru.dublgis.offscreenview/OffscreenWebView.java \
+    $$PWD/ru.dublgis.offscreenview/OffscreenEditText.java


### PR DESCRIPTION
Когда подключаешь либу QtOffscreenViews невозможно зарегестрировать qml классы, потому что их файлы не добавлены в библиотеку.
Ну и $$PWD для порядку.